### PR TITLE
feat: enforce access rules and squad membership

### DIFF
--- a/src/app/api/competitions/[competitionId]/editions/route.ts
+++ b/src/app/api/competitions/[competitionId]/editions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createEdition } from "@/modules/competitions/service";
+import { assertCompetitionAdminAccess } from "@/server/api/access";
 import { createApiHandler } from "@/server/api/handler";
 
 type CreateEditionBody = {
@@ -52,6 +53,7 @@ export const POST = createApiHandler<RouteParams>(
         { status: 400 },
       );
     }
+    await assertCompetitionAdminAccess(competitionId, auth);
 
     const payload = (await request.json()) as CreateEditionBody;
 

--- a/src/app/api/entries/[entryId]/squads/route.ts
+++ b/src/app/api/entries/[entryId]/squads/route.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { ensureSquad } from "@/modules/entries/service";
+import { assertEntryAccess } from "@/server/api/access";
 import { createApiHandler } from "@/server/api/handler";
 import { db } from "@/server/db/client";
 import { squads } from "@/server/db/schema";
@@ -14,11 +15,12 @@ type RequestBody = {
 };
 
 export const PUT = createApiHandler<RouteParams>(
-  async ({ params, request }) => {
+  async ({ params, request, auth }) => {
     const entryId = Array.isArray(params.entryId)
       ? params.entryId[0]
       : params.entryId;
     const payload = (await request.json()) as RequestBody;
+    await assertEntryAccess(entryId, auth);
 
     const squad = await ensureSquad(entryId);
 

--- a/src/app/api/squads/[squadId]/members/route.ts
+++ b/src/app/api/squads/[squadId]/members/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { addSquadMember } from "@/modules/entries/service";
+import { assertSquadAccess } from "@/server/api/access";
 import { createApiHandler } from "@/server/api/handler";
 
 type RouteParams = {
@@ -15,10 +16,11 @@ type RequestBody = {
 };
 
 export const POST = createApiHandler<RouteParams>(
-  async ({ params, request }) => {
+  async ({ params, request, auth }) => {
     const squadId = Array.isArray(params.squadId)
       ? params.squadId[0]
       : params.squadId;
+    await assertSquadAccess(squadId, auth);
     const payload = (await request.json()) as RequestBody;
 
     const member = await addSquadMember({

--- a/src/app/api/teams/[teamId]/members/route.ts
+++ b/src/app/api/teams/[teamId]/members/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { addRosterMember } from "@/modules/teams/service";
+import { assertTeamAccess } from "@/server/api/access";
 import { createApiHandler } from "@/server/api/handler";
 
 type RouteParams = {
@@ -16,10 +17,11 @@ type RequestBody = {
 };
 
 export const POST = createApiHandler<RouteParams>(
-  async ({ params, request }) => {
+  async ({ params, request, auth }) => {
     const teamId = Array.isArray(params.teamId)
       ? params.teamId[0]
       : params.teamId;
+    await assertTeamAccess(teamId, auth);
     const payload = (await request.json()) as RequestBody;
 
     const member = await addRosterMember({

--- a/src/app/api/teams/[teamId]/route.ts
+++ b/src/app/api/teams/[teamId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { listTeamRoster } from "@/modules/teams/service";
+import { assertTeamAccess } from "@/server/api/access";
 import { createApiHandler } from "@/server/api/handler";
 
 type RouteParams = {
@@ -7,10 +8,11 @@ type RouteParams = {
 };
 
 export const GET = createApiHandler<RouteParams>(
-  async ({ params }) => {
+  async ({ params, auth }) => {
     const teamId = Array.isArray(params.teamId)
       ? params.teamId[0]
       : params.teamId;
+    await assertTeamAccess(teamId, auth);
     const roster = await listTeamRoster(teamId);
 
     return NextResponse.json(

--- a/src/modules/entries/__tests__/unit/squad-membership.test.ts
+++ b/src/modules/entries/__tests__/unit/squad-membership.test.ts
@@ -1,0 +1,124 @@
+import { sql } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ProblemError } from "@/lib/errors/problem";
+import { addSquadMember } from "@/modules/entries/service";
+import { db } from "@/server/db/client";
+import {
+  competitions,
+  editions,
+  entries,
+  persons,
+  squads,
+  teamMemberships,
+  teams,
+} from "@/server/db/schema";
+
+async function resetDb() {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      squad_members,
+      squads,
+      entries,
+      team_memberships,
+      persons,
+      teams,
+      editions,
+      competitions
+    RESTART IDENTITY CASCADE;
+  `);
+}
+
+describe("addSquadMember", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("rejects adding a membership from another team", async () => {
+    const [competition] = await db
+      .insert(competitions)
+      .values({
+        name: "Elite Cup",
+        slug: "elite-cup",
+        defaultTimezone: "UTC",
+      })
+      .returning();
+    if (!competition) {
+      throw new Error("Expected competition to be created.");
+    }
+
+    const [edition] = await db
+      .insert(editions)
+      .values({
+        competitionId: competition.id,
+        label: "2025",
+        slug: "2025",
+        format: "round_robin",
+        timezone: "UTC",
+      })
+      .returning();
+    if (!edition) {
+      throw new Error("Expected edition to be created.");
+    }
+
+    const [teamA] = await db
+      .insert(teams)
+      .values({ name: "Team A", slug: "team-a" })
+      .returning();
+    const [teamB] = await db
+      .insert(teams)
+      .values({ name: "Team B", slug: "team-b" })
+      .returning();
+    if (!teamA || !teamB) {
+      throw new Error("Expected teams to be created.");
+    }
+
+    const [entry] = await db
+      .insert(entries)
+      .values({
+        editionId: edition.id,
+        teamId: teamA.id,
+      })
+      .returning();
+    if (!entry) {
+      throw new Error("Expected entry to be created.");
+    }
+
+    const [squad] = await db
+      .insert(squads)
+      .values({ entryId: entry.id })
+      .returning();
+    if (!squad) {
+      throw new Error("Expected squad to be created.");
+    }
+
+    const [person] = await db
+      .insert(persons)
+      .values({ firstName: "Pat", lastName: "Player" })
+      .returning();
+    if (!person) {
+      throw new Error("Expected person to be created.");
+    }
+
+    const [membership] = await db
+      .insert(teamMemberships)
+      .values({
+        teamId: teamB.id,
+        personId: person.id,
+      })
+      .returning();
+    if (!membership) {
+      throw new Error("Expected membership to be created.");
+    }
+
+    try {
+      await addSquadMember({
+        squadId: squad.id,
+        membershipId: membership.id,
+      });
+      throw new Error("expected addSquadMember to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProblemError);
+      expect((error as ProblemError).problem.status).toBe(409);
+    }
+  });
+});

--- a/src/modules/entries/service.ts
+++ b/src/modules/entries/service.ts
@@ -244,6 +244,20 @@ export async function addSquadMember(
       });
     }
 
+    const entry = await tx.query.entries.findFirst({
+      columns: { teamId: true },
+      where: eq(entries.id, squad.entryId),
+    });
+
+    if (!entry) {
+      throw createProblem({
+        type: "https://tournament.app/problems/entry-not-found",
+        title: "Påmeldingen ble ikke funnet",
+        status: 404,
+        detail: "Påmeldingen ble ikke funnet.",
+      });
+    }
+
     const membership = await tx.query.teamMemberships.findFirst({
       where: eq(teamMemberships.id, input.membershipId),
     });
@@ -254,6 +268,15 @@ export async function addSquadMember(
         title: "Medlemskapet ble ikke funnet",
         status: 404,
         detail: "Velg en spiller fra laglisten.",
+      });
+    }
+
+    if (membership.teamId !== entry.teamId) {
+      throw createProblem({
+        type: "https://tournament.app/problems/squad-member-team-mismatch",
+        title: "Ugyldig lag",
+        status: 409,
+        detail: "Spilleren tilhører ikke laget som er registrert i troppen.",
       });
     }
 

--- a/src/server/api/__tests__/access.test.ts
+++ b/src/server/api/__tests__/access.test.ts
@@ -1,0 +1,90 @@
+import { sql } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ProblemError } from "@/lib/errors/problem";
+import { assertTeamAccess } from "@/server/api/access";
+import type { AuthContext, RoleAssignment } from "@/server/auth";
+import { db } from "@/server/db/client";
+import { teams } from "@/server/db/schema";
+
+const baseSession = {
+  id: "session-1",
+  userId: "user-1",
+  expiresAt: new Date(Date.now() + 60_000),
+  token: "token-1",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ipAddress: "127.0.0.1",
+  userAgent: "vitest",
+};
+
+const baseUser = {
+  id: "user-1",
+  email: "manager@example.com",
+  name: "Team Manager",
+  emailVerified: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeAuth(roles: RoleAssignment[]): AuthContext {
+  return {
+    session: baseSession,
+    user: {
+      ...baseUser,
+      roles,
+    },
+  } as AuthContext;
+}
+
+async function resetDb() {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      squad_members,
+      squads,
+      entries,
+      team_memberships,
+      persons,
+      teams,
+      editions,
+      competitions
+    RESTART IDENTITY CASCADE;
+  `);
+}
+
+describe("access control", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("allows team_manager access to its own team and denies other teams", async () => {
+    const [teamA] = await db
+      .insert(teams)
+      .values({ name: "Team A", slug: "team-a" })
+      .returning();
+    const [teamB] = await db
+      .insert(teams)
+      .values({ name: "Team B", slug: "team-b" })
+      .returning();
+    if (!teamA || !teamB) {
+      throw new Error("Expected teams to be created.");
+    }
+
+    const auth = makeAuth([
+      {
+        role: "team_manager",
+        scopeType: "team",
+        scopeId: teamA.id,
+      },
+    ]);
+
+    await expect(assertTeamAccess(teamA.id, auth)).resolves.toBeUndefined();
+
+    try {
+      await assertTeamAccess(teamB.id, auth);
+      throw new Error("expected access to be denied");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProblemError);
+      expect((error as ProblemError).problem.status).toBe(403);
+    }
+  });
+});

--- a/src/server/api/access.ts
+++ b/src/server/api/access.ts
@@ -1,0 +1,340 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { createProblem } from "@/lib/errors/problem";
+import { type AuthContext, userHasRole } from "@/server/auth";
+import { db } from "@/server/db/client";
+import { editions, entries, squads, teams } from "@/server/db/schema";
+
+type AccessContext = {
+  teamId: string;
+  competitionId: string;
+};
+
+function requireAuth(auth: AuthContext | null): AuthContext {
+  if (!auth) {
+    throw createProblem({
+      type: "https://httpstatuses.com/401",
+      title: "Autentisering kreves",
+      status: 401,
+      detail: "Du må være innlogget for å utføre denne handlingen.",
+    });
+  }
+
+  return auth;
+}
+
+function getCompetitionScopeIds(auth: AuthContext): string[] {
+  return auth.user.roles
+    .filter(
+      (assignment) =>
+        assignment.role === "competition_admin" &&
+        assignment.scopeType === "competition" &&
+        assignment.scopeId,
+    )
+    .map((assignment) => assignment.scopeId as string);
+}
+
+function hasTeamScope(auth: AuthContext, teamId: string): boolean {
+  return auth.user.roles.some(
+    (assignment) =>
+      assignment.role === "team_manager" &&
+      assignment.scopeType === "team" &&
+      assignment.scopeId === teamId,
+  );
+}
+
+function hasCompetitionScope(
+  auth: AuthContext,
+  competitionId: string,
+): boolean {
+  return auth.user.roles.some(
+    (assignment) =>
+      assignment.role === "competition_admin" &&
+      assignment.scopeType === "competition" &&
+      assignment.scopeId === competitionId,
+  );
+}
+
+export async function assertCompetitionAdminAccess(
+  competitionId: string | undefined,
+  auth: AuthContext | null,
+): Promise<void> {
+  if (!competitionId) {
+    throw createProblem({
+      type: "https://httpstatuses.com/400",
+      title: "Ugyldig forespørsel",
+      status: 400,
+      detail: "CompetitionId mangler i URLen.",
+    });
+  }
+
+  const session = requireAuth(auth);
+
+  if (userHasRole(session, "global_admin")) {
+    return;
+  }
+
+  if (!hasCompetitionScope(session, competitionId)) {
+    throw createProblem({
+      type: "https://httpstatuses.com/403",
+      title: "Ingen tilgang",
+      status: 403,
+      detail: "Du har ikke rettigheter til å administrere konkurransen.",
+    });
+  }
+}
+
+export async function assertTeamAccess(
+  teamId: string | undefined,
+  auth: AuthContext | null,
+): Promise<void> {
+  if (!teamId) {
+    throw createProblem({
+      type: "https://httpstatuses.com/400",
+      title: "Ugyldig forespørsel",
+      status: 400,
+      detail: "TeamId mangler i URLen.",
+    });
+  }
+
+  const session = requireAuth(auth);
+
+  const team = await db.query.teams.findFirst({
+    columns: { id: true },
+    where: eq(teams.id, teamId),
+  });
+
+  if (!team) {
+    throw createProblem({
+      type: "https://tournament.app/problems/team-not-found",
+      title: "Teamet ble ikke funnet",
+      status: 404,
+      detail: "Sjekk at du bruker riktig team-ID.",
+    });
+  }
+
+  if (userHasRole(session, "global_admin")) {
+    return;
+  }
+
+  if (hasTeamScope(session, teamId)) {
+    return;
+  }
+
+  const competitionScopeIds = getCompetitionScopeIds(session);
+  if (!competitionScopeIds.length) {
+    throw createProblem({
+      type: "https://httpstatuses.com/403",
+      title: "Ingen tilgang",
+      status: 403,
+      detail: "Du har ikke tilgang til dette laget.",
+    });
+  }
+
+  const rows = await db
+    .select({ entryId: entries.id })
+    .from(entries)
+    .innerJoin(editions, eq(entries.editionId, editions.id))
+    .where(
+      and(
+        eq(entries.teamId, teamId),
+        inArray(editions.competitionId, competitionScopeIds),
+      ),
+    )
+    .limit(1);
+
+  if (!rows.length) {
+    throw createProblem({
+      type: "https://httpstatuses.com/403",
+      title: "Ingen tilgang",
+      status: 403,
+      detail: "Du har ikke tilgang til dette laget.",
+    });
+  }
+}
+
+export async function assertEntryAccess(
+  entryId: string | undefined,
+  auth: AuthContext | null,
+): Promise<AccessContext> {
+  if (!entryId) {
+    throw createProblem({
+      type: "https://httpstatuses.com/400",
+      title: "Ugyldig forespørsel",
+      status: 400,
+      detail: "EntryId mangler i forespørselen.",
+    });
+  }
+
+  const session = requireAuth(auth);
+
+  const rows = await db
+    .select({
+      entryId: entries.id,
+      teamId: entries.teamId,
+      competitionId: editions.competitionId,
+    })
+    .from(entries)
+    .innerJoin(editions, eq(entries.editionId, editions.id))
+    .where(eq(entries.id, entryId))
+    .limit(1);
+
+  const record = rows[0];
+  if (!record) {
+    throw createProblem({
+      type: "https://tournament.app/problems/entry-not-found",
+      title: "Påmeldingen ble ikke funnet",
+      status: 404,
+      detail: "Påmeldingen ble ikke funnet.",
+    });
+  }
+
+  if (userHasRole(session, "global_admin")) {
+    return { teamId: record.teamId, competitionId: record.competitionId };
+  }
+
+  if (hasCompetitionScope(session, record.competitionId)) {
+    return { teamId: record.teamId, competitionId: record.competitionId };
+  }
+
+  if (hasTeamScope(session, record.teamId)) {
+    return { teamId: record.teamId, competitionId: record.competitionId };
+  }
+
+  throw createProblem({
+    type: "https://httpstatuses.com/403",
+    title: "Ingen tilgang",
+    status: 403,
+    detail: "Du har ikke tilgang til denne påmeldingen.",
+  });
+}
+
+export async function assertSquadAccess(
+  squadId: string | undefined,
+  auth: AuthContext | null,
+): Promise<AccessContext> {
+  if (!squadId) {
+    throw createProblem({
+      type: "https://httpstatuses.com/400",
+      title: "Ugyldig forespørsel",
+      status: 400,
+      detail: "SquadId mangler i URLen.",
+    });
+  }
+
+  const session = requireAuth(auth);
+
+  const rows = await db
+    .select({
+      squadId: squads.id,
+      teamId: entries.teamId,
+      competitionId: editions.competitionId,
+    })
+    .from(squads)
+    .innerJoin(entries, eq(squads.entryId, entries.id))
+    .innerJoin(editions, eq(entries.editionId, editions.id))
+    .where(eq(squads.id, squadId))
+    .limit(1);
+
+  const record = rows[0];
+  if (!record) {
+    throw createProblem({
+      type: "https://tournament.app/problems/squad-not-found",
+      title: "Troppen ble ikke funnet",
+      status: 404,
+      detail: "Oppdater siden og prøv igjen.",
+    });
+  }
+
+  if (userHasRole(session, "global_admin")) {
+    return { teamId: record.teamId, competitionId: record.competitionId };
+  }
+
+  if (hasCompetitionScope(session, record.competitionId)) {
+    return { teamId: record.teamId, competitionId: record.competitionId };
+  }
+
+  if (hasTeamScope(session, record.teamId)) {
+    return { teamId: record.teamId, competitionId: record.competitionId };
+  }
+
+  throw createProblem({
+    type: "https://httpstatuses.com/403",
+    title: "Ingen tilgang",
+    status: 403,
+    detail: "Du har ikke tilgang til denne troppen.",
+  });
+}
+
+export async function assertTeamEntryCreateAccess(
+  teamId: string | undefined,
+  editionId: string | undefined,
+  auth: AuthContext | null,
+): Promise<void> {
+  if (!teamId) {
+    throw createProblem({
+      type: "https://httpstatuses.com/400",
+      title: "Ugyldig forespørsel",
+      status: 400,
+      detail: "TeamId mangler i URLen.",
+    });
+  }
+
+  if (!editionId) {
+    throw createProblem({
+      type: "https://httpstatuses.com/400",
+      title: "Ugyldig forespørsel",
+      status: 400,
+      detail: "EditionId mangler i forespørselen.",
+    });
+  }
+
+  const session = requireAuth(auth);
+
+  const [team, edition] = await Promise.all([
+    db.query.teams.findFirst({
+      columns: { id: true },
+      where: eq(teams.id, teamId),
+    }),
+    db.query.editions.findFirst({
+      columns: { id: true, competitionId: true },
+      where: eq(editions.id, editionId),
+    }),
+  ]);
+
+  if (!team) {
+    throw createProblem({
+      type: "https://tournament.app/problems/team-not-found",
+      title: "Teamet ble ikke funnet",
+      status: 404,
+      detail: "Sjekk at du bruker riktig team-ID.",
+    });
+  }
+
+  if (!edition) {
+    throw createProblem({
+      type: "https://tournament.app/problems/edition-not-found",
+      title: "Utgaven ble ikke funnet",
+      status: 404,
+      detail: "Utgaven du prøver å melde på laget til finnes ikke.",
+    });
+  }
+
+  if (userHasRole(session, "global_admin")) {
+    return;
+  }
+
+  if (hasTeamScope(session, teamId)) {
+    return;
+  }
+
+  if (hasCompetitionScope(session, edition.competitionId)) {
+    return;
+  }
+
+  throw createProblem({
+    type: "https://httpstatuses.com/403",
+    title: "Ingen tilgang",
+    status: 403,
+    detail: "Du har ikke tilgang til å registrere dette laget.",
+  });
+}

--- a/src/server/api/handler.ts
+++ b/src/server/api/handler.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
+import { env } from "@/env";
 import {
   createProblem,
   ensureProblem,
@@ -11,6 +12,7 @@ import {
   getSession,
   type Role,
   requireRoles,
+  resolveTrustedOrigins,
 } from "@/server/auth";
 
 type RouteParams = Record<string, string | string[]>;
@@ -40,6 +42,91 @@ function unauthorizedProblem(): ProblemDetails {
   };
 }
 
+function isStateChangingMethod(method: string): boolean {
+  return ["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
+}
+
+function wildcardMatch(value: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+  return regex.test(value);
+}
+
+function matchesOrigin(origin: string, pattern: string): boolean {
+  if (!pattern.includes("*")) {
+    if (pattern.includes("://")) {
+      return origin === pattern;
+    }
+    const host = new URL(origin).host;
+    return host === pattern;
+  }
+
+  if (pattern.includes("://")) {
+    return wildcardMatch(origin, pattern);
+  }
+
+  const host = new URL(origin).host;
+  return wildcardMatch(host, pattern);
+}
+
+function extractOrigin(raw: string): string | null {
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return null;
+  }
+}
+
+function enforceSameOrigin(request: NextRequest): void {
+  if (env.NODE_ENV === "test") {
+    return;
+  }
+
+  if (!isStateChangingMethod(request.method)) {
+    return;
+  }
+
+  if (!request.headers.has("cookie")) {
+    return;
+  }
+
+  const originHeader =
+    request.headers.get("origin") ?? request.headers.get("referer");
+
+  if (!originHeader || originHeader === "null") {
+    throw createProblem({
+      type: "https://httpstatuses.com/403",
+      title: "Invalid origin",
+      status: 403,
+      detail: "Missing or invalid Origin header.",
+    });
+  }
+
+  const origin = extractOrigin(originHeader);
+  if (!origin) {
+    throw createProblem({
+      type: "https://httpstatuses.com/403",
+      title: "Invalid origin",
+      status: 403,
+      detail: "Origin header could not be parsed.",
+    });
+  }
+
+  const trustedOrigins = resolveTrustedOrigins();
+  const allowed = trustedOrigins.some((pattern) =>
+    matchesOrigin(origin, pattern),
+  );
+
+  if (!allowed) {
+    throw createProblem({
+      type: "https://httpstatuses.com/403",
+      title: "Invalid origin",
+      status: 403,
+      detail: "Origin is not allowed for this request.",
+    });
+  }
+}
+
 export function createApiHandler<
   TParams extends RouteParams = Record<string, never>,
 >(handler: RouteHandler<TParams>, options: HandlerOptions = {}) {
@@ -63,6 +150,8 @@ export function createApiHandler<
 
       try {
         const shouldRequireAuth = options.requireAuth ?? false;
+
+        enforceSameOrigin(request);
 
         const session = await getSession(request);
 

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -109,7 +109,7 @@ export function userHasRole(context: AuthContext | null, role: Role): boolean {
   );
 }
 
-function resolveTrustedOrigins(): string[] {
+export function resolveTrustedOrigins(): string[] {
   const defaults = ["http://localhost:3000", env.NEXT_PUBLIC_APP_URL].filter(
     Boolean,
   ) as string[];


### PR DESCRIPTION
## Summary
- add shared access helpers for teams, entries, squads, and competitions
- enforce access checks in team, squad, entry, and competition routes
- ensure squad members belong to the entry team, with coverage
- add tests for access and squad membership validation
- add same-origin protection for cookie-based state-changing requests

## Testing
- npm run lint
- npm run tsc