### PR TITLE
fix: force dynamic competition routes

### DIFF
--- a/src/app/(dashboard)/dashboard/competitions/[competitionId]/editions/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/competitions/[competitionId]/editions/new/page.tsx
@@ -13,6 +13,8 @@ export const metadata: Metadata = {
   description: "Opprett en ny utgave for konkurransen og tilpass storskjermen.",
 };
 
+export const dynamic = "force-dynamic";
+
 export default function EditionNewPage({ params }: PageProps) {
   const competitionId = params.competitionId;
   if (!competitionId) {

--- a/src/app/(dashboard)/dashboard/competitions/[competitionId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/competitions/[competitionId]/page.tsx
@@ -18,6 +18,8 @@ type PageProps = {
   };
 };
 
+export const dynamic = "force-dynamic";
+
 const datetimeFormatter = new Intl.DateTimeFormat("nb-NO", {
   dateStyle: "medium",
   timeStyle: "short",


### PR DESCRIPTION
## Summary
- force dynamic rendering for competition detail and new edition routes
- prevent static optimization from returning 404s for UUID-based pages
