### PR TITLE
docs: whitelist turnering.vanvikil.no origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/tournament_app"
 # better-auth secrets and email identity
 BETTER_AUTH_SECRET="change-me-change-me-change-me-change-me"
 BETTER_AUTH_EMAIL_SENDER="no-reply@example.com"
-BETTER_AUTH_TRUSTED_ORIGINS="http://localhost:3000"
+BETTER_AUTH_TRUSTED_ORIGINS="http://localhost:3000,http://turnering.vanvikil.no"
 
 # Amazon SES (invitasjoner)
 SES_ENABLED="false"


### PR DESCRIPTION
## Summary
- add turnering.vanvikil.no to BETTER_AUTH_TRUSTED_ORIGINS example

## Notes
- set BETTER_AUTH_TRUSTED_ORIGINS in the deployment env to include http://turnering.vanvikil.no