### PR TITLE
fix: add Powertools logging to better-auth routes for CloudWatch visibility

### DIFF
--- a/src/app/api/auth/[...better-auth]/route.ts
+++ b/src/app/api/auth/[...better-auth]/route.ts
@@ -1,9 +1,59 @@
 import { toNextJsHandler } from "better-auth/next-js";
+import type { NextRequest } from "next/server";
+import { logger } from "@/lib/logger/powertools";
 import { auth } from "@/server/auth";
 
-const handler = toNextJsHandler(auth);
+const betterAuthHandler = toNextJsHandler(auth);
 
 export const dynamic = "force-dynamic";
 
-export const GET = handler.GET;
-export const POST = handler.POST;
+/**
+ * Wrap better-auth handlers with Powertools logging.
+ * This ensures auth requests/errors are visible in CloudWatch.
+ */
+function withLogging(
+  handler: (req: NextRequest) => Promise<Response>,
+  method: string,
+) {
+  return async (req: NextRequest): Promise<Response> => {
+    const startTime = Date.now();
+    const path = req.nextUrl.pathname;
+
+    logger.appendKeys({
+      method,
+      path,
+      authEndpoint: path.replace("/api/auth/", ""),
+    });
+
+    try {
+      logger.info("auth_request_started");
+
+      const response = await handler(req);
+
+      const durationMs = Date.now() - startTime;
+      logger.info("auth_request_completed", {
+        durationMs,
+        status: response.status,
+      });
+
+      return response;
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error ? error.stack : undefined;
+
+      logger.error("auth_request_failed", {
+        durationMs,
+        error: message,
+        stack,
+      });
+
+      throw error;
+    } finally {
+      logger.removeKeys(["method", "path", "authEndpoint"]);
+    }
+  };
+}
+
+export const GET = withLogging(betterAuthHandler.GET, "GET");
+export const POST = withLogging(betterAuthHandler.POST, "POST");


### PR DESCRIPTION
## Summary

- Wrap better-auth routes with Powertools logging so auth requests and errors are visible in CloudWatch

## Problem

The better-auth handler was using `toNextJsHandler` directly, which bypassed our `createApiHandler` wrapper. This meant:

1. Auth requests (login, signup, session) were not logged to CloudWatch
2. Auth errors (including the "signature mismatch" error) were invisible in logs
3. No visibility into auth request latency or failure patterns

## Solution

Wrapped the better-auth handlers with a logging middleware that:

- Logs `auth_request_started` at the beginning of each request
- Logs `auth_request_completed` with duration and status on success
- Logs `auth_request_failed` with error details on failure
- Adds context keys: `method`, `path`, `authEndpoint` (e.g., "sign-in/email")

## Example Log Output

```json
{
  "level": "INFO",
  "message": "auth_request_started",
  "service": "competitions",
  "method": "POST",
  "path": "/api/auth/sign-in/email",
  "authEndpoint": "sign-in/email"
}
```

```json
{
  "level": "ERROR",
  "message": "auth_request_failed",
  "service": "competitions",
  "durationMs": 123,
  "error": "The request signature we calculated does not match...",
  "stack": "..."
}
```

## Note on the "Signature Mismatch" Error

This error typically indicates:
1. **Clock skew** - Unlikely in AWS Lambda
2. **Misconfigured credentials** - If `SES_ACCESS_KEY_ID`/`SES_SECRET_ACCESS_KEY` are set incorrectly
3. **IAM role issues** - The Lambda IAM role should have SES permissions (which it does via Terraform)

The Terraform config does NOT pass `SES_ACCESS_KEY_ID`/`SES_SECRET_ACCESS_KEY` to Lambda - it relies on the IAM role. If you have these env vars set elsewhere (e.g., in GitHub secrets or manual config), they might be incorrect.

## Testing

- ✅ `npm run tsc` passes
- ✅ `npm run lint` passes
- ✅ `npm test` passes