### PR TITLE
fix: add x-amz-content-sha256 header to auth requests for CloudFront OAC

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -2,12 +2,20 @@
 
 import { createAuthClient } from "better-auth/react";
 
+import { amzContentSha256FetchPlugin } from "@/lib/api/amz-content-sha256";
+
 /**
  * Browser-side auth client for better-auth.
  * Use this in client components to sign in, sign up, sign out, etc.
+ *
+ * The amzContentSha256FetchPlugin adds the x-amz-content-sha256 header to POST/PUT
+ * requests, which is required for CloudFront OAC with Lambda Function URL using AWS_IAM auth.
  */
 export const authClient = createAuthClient({
   baseURL: typeof window !== "undefined" ? window.location.origin : undefined,
+  fetchOptions: {
+    plugins: [amzContentSha256FetchPlugin],
+  },
 });
 
 export const { signIn, signUp, signOut, useSession } = authClient;


### PR DESCRIPTION
## Summary
- Fixes 403 signature mismatch errors on POST auth requests (e.g., `/api/auth/sign-in/email`)
- Adds the `x-amz-content-sha256` header required by CloudFront OAC with Lambda Function URL using AWS_IAM auth

## Problem
CloudFront OAC signs requests to Lambda using SigV4, which includes the body hash in the signature calculation. Without the `x-amz-content-sha256` header from the client, CloudFront can't properly sign POST/PUT requests with bodies, resulting in:

> "The request signature we calculated does not match the signature you provided"

## Solution
Added the `amzContentSha256FetchPlugin` to the better-auth client, which:
1. Computes SHA256 hash of the request body using native `crypto.subtle.digest`
2. Adds it as the `x-amz-content-sha256` header for POST/PUT requests

This matches the fix applied in the mattis repo (commit `73bca7b`).