### PR TITLE
fix(scoreboard): show full schedule and hide empty upcoming scores

### DIFF
--- a/src/ui/components/scoreboard/scoreboard-layout.tsx
+++ b/src/ui/components/scoreboard/scoreboard-layout.tsx
@@ -708,6 +708,7 @@ function LandingLayout({
     (match) => match.status === "scheduled",
   );
   const nextMatches = upcomingMatches.slice(0, 4);
+  const hasLiveMatches = liveMatches.length > 0;
 
   return (
     <div className="space-y-8">
@@ -720,12 +721,14 @@ function LandingLayout({
         </div>
       ) : null}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <MatchSection
-          title="Live nå"
-          matches={liveMatches}
-          emptyText="Ingen kamper pågår akkurat nå."
-        />
+      <div className={`grid gap-6 ${hasLiveMatches ? "lg:grid-cols-2" : ""}`}>
+        {hasLiveMatches ? (
+          <MatchSection
+            title="Live nå"
+            matches={liveMatches}
+            emptyText="Ingen kamper pågår akkurat nå."
+          />
+        ) : null}
         <MatchSection
           title="Neste kamper"
           matches={nextMatches}


### PR DESCRIPTION
## Summary
- show all matches in Kampoversikt instead of only the next four
- hide the empty score box for scheduled matches in Neste kamper
- hide the Live nå section when there are no live matches

## Testing
- npm run lint
- npm run tsc
- npm test
- npm run build