### PR TITLE
fix(entries): add targetWhere for partial index on squad_members

### DIFF
--- a/src/modules/entries/service.ts
+++ b/src/modules/entries/service.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { createProblem } from "@/lib/errors/problem";
 import { db, withTransaction } from "@/server/db/client";
 import {
@@ -294,6 +294,7 @@ export async function addSquadMember(
       })
       .onConflictDoUpdate({
         target: [squadMembers.squadId, squadMembers.membershipId],
+        targetWhere: sql`${squadMembers.membershipId} IS NOT NULL`,
         set: {
           jerseyNumber:
             typeof input.jerseyNumber === "number" ? input.jerseyNumber : null,


### PR DESCRIPTION
## Summary

Fixes 500 error when adding squad members via POST `/api/squads/{id}/members`.

## Root Cause

The unique index `squad_members_unique_membership` on `(squad_id, membership_id)` is a **partial index** with the condition `WHERE membership_id IS NOT NULL`. PostgreSQL's `ON CONFLICT` clause requires matching the WHERE clause of partial indexes - just specifying the target columns is not enough.

## Fix

Added `targetWhere: sql\`membership_id IS NOT NULL\`` to the `onConflictDoUpdate` call in `addSquadMember()` to properly match the partial index.

## Testing

- All existing tests pass
- Verified the generated SQL now includes the correct WHERE clause for conflict resolution