### PR TITLE
chore(iac): harden SES SNS topic policy with SourceArn condition

### DIFF
--- a/iac/locals.tf
+++ b/iac/locals.tf
@@ -56,6 +56,10 @@ locals {
   ses_mail_from_domain        = local.ses_mail_from_input != "" ? local.ses_mail_from_input : "mail.${local.ses_domain}"
   ses_configuration_set_name  = local.ses_configuration_set_input != "" ? local.ses_configuration_set_input : "${local.stack_name}-ses"
   ses_event_topic_name        = local.ses_event_topic_input != "" ? local.ses_event_topic_input : "${local.stack_name}-ses-events"
+  # AWS best practice: use SourceArn to restrict to specific configuration set
+  ses_configuration_set_arn = local.ses_configuration_set_name != "" ? (
+    "arn:aws:ses:${local.ses_region}:${data.aws_caller_identity.current.account_id}:configuration-set/${local.ses_configuration_set_name}"
+  ) : ""
 
   dmarc_value = local.ses_dmarc_rua_input != "" ? "v=DMARC1; p=${var.ses_dmarc_policy}; rua=mailto:${local.ses_dmarc_rua_input}" : "v=DMARC1; p=${var.ses_dmarc_policy}"
 }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -276,10 +276,18 @@ data "aws_iam_policy_document" "ses_events" {
     actions   = ["sns:Publish"]
     resources = [aws_sns_topic.ses_events[0].arn]
 
+    # AWS best practice: use both SourceAccount and SourceArn conditions
+    # https://docs.aws.amazon.com/ses/latest/dg/event-publishing-add-event-destination-sns.html
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceAccount"
       values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [local.ses_configuration_set_arn]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `AWS:SourceArn` condition to SES events SNS topic policy to restrict publishing to only the specific SES configuration set
- Add `ses_configuration_set_arn` local variable to construct the ARN

This aligns Tournament with the hardened SES policy already implemented in Mattis, following AWS best practices for least privilege access.

## Reference
- [AWS SES Event Publishing Documentation](https://docs.aws.amazon.com/ses/latest/dg/event-publishing-add-event-destination-sns.html)