### PR TITLE
chore(iac): upgrade AWS provider to ~> 6.21 for nodejs24.x support

### DIFF
--- a/iac/versions.tf
+++ b/iac/versions.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.16"
+      version = "~> 6.21"
     }
 
     neon = {


### PR DESCRIPTION
## Summary
- Upgrade AWS provider constraint from `~> 6.16` to `~> 6.21` for explicit `nodejs24.x` Lambda runtime support
- Aligns with Mattis repo which was upgraded in PR #67