### PR TITLE
refactor: remove explicit `any`/casts and tighten lint/tsconfig to forbid them

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -31,7 +31,9 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noConsole": "error"
+        "noConsole": "error",
+        "noExplicitAny": "error",
+        "noImplicitAnyLet": "error"
       }
     },
     "domains": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### Motivation
- Remove runtime and test usages of `any` and ad-hoc type casts to improve type safety.
- Prevent regressions by enabling linter/TS rules that surface `any` usage going forward.
- Keep test and dev workflow stable while removing unsafe casts in mocks and test helpers.

### Description
- Replaced loose typing in the test DB mock by importing `pushSchema` directly and wiring a typed `withTransaction` helper in `src/test/setup.ts` and returning `db: schemaDb` instead of using `as any` or untyped callbacks.
- Simplified accessibility tests in `src/ui/__tests__/accessibility.test.tsx` by removing custom `vitest-axe` matcher declarations and type assertions, using `results.violations` and a typed `Pa11yOptions` for `pa11y` invocation.
- Tightened Biome lint rules in `biome.json` to enable `noExplicitAny` and `noImplicitAnyLet` as errors to prevent future `any` usage.
- Enabled `noImplicitAny` in `tsconfig.json` so the TypeScript compiler will surface implicit `any` occurrences.

### Testing
- Ran `npm run lint` which generated types and ran Biome checks and completed with no reported linter errors.
- Ran `npm run tsc` (`tsc --noEmit`) and the TypeScript build completed without errors.
- Ran the full test suite via `npm test` (Vitest) and all automated tests passed (test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a53ecc188333a98d072db0b06ba2)