### PR TITLE
fix(iac): allow ses:SendEmail on configuration set

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -233,10 +233,13 @@ module "fn" {
 
 data "aws_iam_policy_document" "ses_send" {
   statement {
-    sid       = "AllowSesSend"
-    effect    = "Allow"
-    actions   = ["ses:SendEmail", "ses:SendRawEmail"]
-    resources = [aws_ses_domain_identity.app.arn]
+    sid     = "AllowSesSend"
+    effect  = "Allow"
+    actions = ["ses:SendEmail", "ses:SendRawEmail"]
+    resources = compact([
+      aws_ses_domain_identity.app.arn,
+      local.ses_configuration_set_arn
+    ])
   }
 }
 


### PR DESCRIPTION
## Summary
- Updates IAM policy to explicitly allow `ses:SendEmail` on the SES configuration set resource.
- Fixes `AccessDenied` error when sending emails with a configuration set.
- Uses `compact()` to handle optional configuration set.