### PR TITLE
Fix missing teams in scoreboard screen mode

### DIFF
--- a/src/ui/components/scoreboard/scoreboard-screen.tsx
+++ b/src/ui/components/scoreboard/scoreboard-screen.tsx
@@ -20,7 +20,6 @@ import type {
   ScreenLayoutProps,
 } from "./scoreboard-ui-types";
 import {
-  SCREEN_GROUP_STANDINGS_LIMIT,
   SCREEN_GROUP_TABLES_LIMIT,
   SCREEN_STANDINGS_LIMIT,
 } from "./scoreboard-ui-types";
@@ -55,11 +54,7 @@ export function ScreenLayout({
   // Show all scorers - no limit for screen mode (same as matches)
   const visibleScorers = scorers;
   const visibleTables = useMemo(
-    () =>
-      tables.slice(0, SCREEN_GROUP_TABLES_LIMIT).map((table) => ({
-        ...table,
-        standings: table.standings.slice(0, SCREEN_GROUP_STANDINGS_LIMIT),
-      })),
+    () => tables.slice(0, SCREEN_GROUP_TABLES_LIMIT),
     [tables],
   );
 

--- a/src/ui/components/scoreboard/scoreboard-ui-types.ts
+++ b/src/ui/components/scoreboard/scoreboard-ui-types.ts
@@ -73,5 +73,4 @@ export const THEME_SOURCE_STORAGE_KEY = "scoreboard-theme-source";
 // No limit - show all matches in screen mode
 export const SCREEN_STANDINGS_LIMIT = 8;
 export const SCREEN_GROUP_TABLES_LIMIT = 6;
-export const SCREEN_GROUP_STANDINGS_LIMIT = 5;
 export const CONTROLS_HIDE_DELAY_MS = 3000;


### PR DESCRIPTION
Fixes an issue in the public scoreboard's screen ("storskjerm") mode where group tables were artificially truncated to only show 5 teams, causing the 6th team to be hidden.

Changes:
- Removed `SCREEN_GROUP_STANDINGS_LIMIT` constant (previously set to `5`) from `scoreboard-ui-types.ts`.
- Removed the `.slice(0, SCREEN_GROUP_STANDINGS_LIMIT)` applied to `table.standings` in `scoreboard-screen.tsx`, allowing all teams in a group to be displayed in the standings.

---
*PR created automatically by Jules for task [1897953338684234572](https://jules.google.com/task/1897953338684234572) started by @kennethaasan*